### PR TITLE
webdriver-gecko: forgot to return the firefox options object

### DIFF
--- a/back-ends/webdriver-gecko.js
+++ b/back-ends/webdriver-gecko.js
@@ -75,6 +75,8 @@ function getBrowserOptions(options) {
 	if (options.userAgent) {
 		firefoxOptions.setPreference("general.useragent.override", options.userAgent);
 	}
+
+    return firefoxOptions;
 }
 
 async function getPageData(driver, options) {


### PR DESCRIPTION
I found a small bug in `webdriver-gecko.js`. The function `getBrowserOptions` wasn't returning anything (`undefined`), when it should return the actual options.