### PR TITLE
Output response status

### DIFF
--- a/args.js
+++ b/args.js
@@ -82,6 +82,7 @@ const args = require("yargs")
 		"max-resource-size": 10,
 		"move-styles-in-head": false,
 		"output-directory": "",
+		"output-status": false,
 		"remove-hidden-elements": true,
 		"remove-unused-styles": true,
 		"remove-unused-fonts": true,
@@ -266,6 +267,8 @@ const args = require("yargs")
 	.string("web-driver-executable-path")
 	.options("output-directory", { description: "Path to where to save files, this path must exist." })
 	.string("output-directory")
+  .options("output-status", { description: "Outputs status of snapshot" })
+  .boolean("output-status")
 	.argv;
 args.backgroundSave = true;
 args.compressCSS = args.compressCss;

--- a/back-ends/puppeteer.js
+++ b/back-ends/puppeteer.js
@@ -190,10 +190,14 @@ async function pageGoto(page, options) {
 		timeout: options.browserLoadMaxTime || 0,
 		waitUntil: options.browserWaitUntil || NETWORK_IDLE_STATE
 	};
+	var response;
 	if (options.content) {
-		await page.goto(options.url, { waitUntil: "domcontentloaded" });
+		response = await page.goto(options.url, { waitUntil: "domcontentloaded" });
 		await page.setContent(options.content, loadOptions);
 	} else {
-		await page.goto(options.url, loadOptions);
+		response = await page.goto(options.url, loadOptions);
+	}
+	if (options.outputStatus){
+	  console.log({status: response.status(), url: response.url(), headers: response.headers()});
 	}
 }

--- a/single-file-cli-api.js
+++ b/single-file-cli-api.js
@@ -69,7 +69,8 @@ const DEFAULT_OPTIONS = {
 	blockFonts: false,
 	blockScripts: true,
 	blockVideos: true,
-	blockAudios: true
+	blockAudios: true,
+	outputStatus: false,
 };
 const STATE_PROCESSING = "processing";
 const STATE_PROCESSED = "processed";


### PR DESCRIPTION
Fixes: https://github.com/gildas-lormeau/single-file-cli/issues/17

Prints out response code (404, 500 etc), URL of capture (useful to see if there are redirects) and misc header info after capture

```
{
  status: 404,
  url: 'http://fakesite.com/doesnotexist',
  headers: {
    connection: 'keep-alive',
    'content-encoding': 'gzip',
    'content-type': 'text/html',
    date: 'Wed, 26 Apr 2023 03:29:34 GMT',
    server: 'nginx/1.18.0 (Ubuntu)',
    'transfer-encoding': 'chunked'
  }
}
```
