### PR TITLE
Add `--version` CLI flag to get version number

### DIFF
--- a/options.js
+++ b/options.js
@@ -146,6 +146,11 @@ function getOptions() {
 		console.log(""); // eslint-disable-line no-console
 		exit(0);
 	}
+	if (options.version) {
+		const version = require('./package.json').version;
+		console.log(version);
+		exit(0);
+	}
 	Object.keys(OPTIONS_INFO).forEach(optionName => {
 		const optionInfo = getOptionInfo(optionName);
 		const optionKey = getOptionKey(optionName, optionInfo);

--- a/options.js
+++ b/options.js
@@ -120,7 +120,8 @@ const OPTIONS_INFO = {
 	"create-root-directory": { description: "Create a root directory based on the timestamp", type: "boolean" },
 	"extract-data-from-page": { description: "Extract compressed data from the page instead of fetching the page in order to create universal self-extracting HTML files", type: "boolean", defaultValue: true },
 	"prevent-appended-data": { description: "Prevent appending data after the compressed data when creating self-extracting HTML files", type: "boolean" },
-	"output-directory": { description: "Path to where to save files, this path must exist.", type: "string" }
+	"output-directory": { description: "Path to where to save files, this path must exist.", type: "string" },
+	"version": { description: "Print the version number and exit.", type: "boolean" }
 };
 
 const { args, exit } = Deno;


### PR DESCRIPTION
ArchiveBox depends on being able to check every dependency version by running `<dependency-binary> --version`.

See here for more info:
- https://github.com/ArchiveBox/ArchiveBox/blob/main/archivebox/config.py#L826
- https://github.com/ArchiveBox/readability-extractor/blob/main/readability-extractor#L16