### PR TITLE
Handle SIGTERM and SIGINT

### DIFF
--- a/lib/deno-polyfill.js
+++ b/lib/deno-polyfill.js
@@ -80,7 +80,7 @@ const Command = DENO_RUNTIME_DETECTED ? Deno.Command : class Command {
 		return {
 			status: new Promise((resolve, reject) => {
 				child.on("exit", code => {
-					if (code === 0 || code === 143) {
+					if (code === 0 || code === 143 || code === 130) {
 						resolve();
 					} else {
 						reject(new Error(`Process exited with code ${code}`));
@@ -108,6 +108,7 @@ const DenoAPI = {
 	remove,
 	stdout,
 	exit,
+	addSignalListener,
 	build,
 	errors,
 	Command
@@ -204,6 +205,14 @@ function exit(code) {
 		Deno.exit(code);
 	} else {
 		process.exit(code);
+	}
+}
+
+function addSignalListener(signal, listener) {
+	if (DENO_RUNTIME_DETECTED) {
+		Deno.addSignalListener(signal, listener);
+	} else {
+		process.once(signal, listener);
 	}
 }
 

--- a/single-file-launcher.js
+++ b/single-file-launcher.js
@@ -22,10 +22,11 @@
  */
 
 import { initialize } from "./single-file-cli-api.js";
+import { closeBrowser } from "./lib/browser.js";
 import { Deno } from "./lib/deno-polyfill.js";
 import options from "./options.js";
 
-const { readTextFile, exit } = Deno;
+const { readTextFile, exit, addSignalListener } = Deno;
 
 export { run };
 
@@ -105,3 +106,13 @@ function parseCookies(textValue) {
 		})
 		.filter(cookieData => cookieData);
 }
+
+addSignalListener('SIGTERM', async () => {
+	await closeBrowser();
+	exit();
+});
+
+addSignalListener('SIGINT', async () => {
+	await closeBrowser();
+	exit();
+});


### PR DESCRIPTION
Currently single-file-cli does not handle SIGTERM and SIGINT. SIGINT occurs when terminating the process though the CLI when pressing <kbd>Cmd/Ctrl+C</kbd>. SIGTERM occurs when running single-file as a child process in another app, and sending the SIGTERM signal to that process so that it can properly terminate itself.

The current behavior is:
- On SIGINT: Chromium does get shut down, but temporary profile folder is not removed
- ON SIGTERM: Chromium is not shut down, temporary profile folder is not removed

This adds listeners for both SIGINT and SIGTERM and runs `closeBrowser` in them, so that both Chromium is terminated and the profile folder is removed.

For testing SIGINT, just start single-file from the CLI and press <kbd>Cmd/Ctrl+C</kbd>. To observe whether the profile was deleted, something can be printed to the console in `closeBrowser`.

For testing SIGTERM I was using these scripts:

<details>
<summary>Deno</summary>

```js
const command = new Deno.Command(Deno.execPath(), {
  args: [
    "run",
    "--allow-read",
    "--allow-write",
    "--allow-run",
    "--allow-net",
    "single-file",
    "https://github.com/wagoodman/dive",
    "test.html",
  ],
  stdin: "piped",
  stdout: "piped",
  stderr: "piped",
});
const subprocess = await command.spawn();
subprocess.stdout.pipeTo(
  Deno.openSync("output", { write: true, create: true }).writable,
);
subprocess.stderr.pipeTo(
  Deno.openSync("output_err", { write: true, create: true }).writable,
);

setTimeout(() => {
  subprocess.kill("SIGTERM");
}, 1000);
```

Run as `deno run --allow-read --allow-write --allow-run test-deno.js`

</details>

<details>
<summary>Node</summary>

```js
import child_process from 'child_process';

const child = child_process.spawn('node', ['single-file-node.js', 'https://github.com/wagoodman/dive', 'test.html']);
child.stdout.pipe(process.stdout);
child.stderr.pipe(process.stderr);

setTimeout(() => {
  child.kill('SIGTERM')
}, 1000);
```

Run as: `node test-node.js`

</details>