### PR TITLE
added browser mobile emulation option with android device by default

### DIFF
--- a/lib/cdp-client.js
+++ b/lib/cdp-client.js
@@ -62,9 +62,18 @@ async function getPageData(options) {
 		}
 		if (options.browserByPassCSP === undefined || options.browserByPassCSP) {
 			await Page.setBypassCSP({ enabled: true });
-		}
-		if (options.browserMobileEmulation) {
-			await Emulation.setDeviceMetricsOverride({ mobile: true });
+		}		
+		if (options.browserMobileEmulation) {					
+			await Emulation.setDeviceMetricsOverride({ 
+				width: 375,
+				height: 812,
+				deviceScaleFactor: 3,
+				mobile: true,
+			 });
+			 await Emulation.setUserAgentOverride({
+				userAgent: "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Mobile Safari/537.36",
+				platform: "Android"				
+			 });
 		}
 		if (options.httpProxyUsername) {
 			await Fetch.enable({ handleAuthRequests: true });

--- a/options.js
+++ b/options.js
@@ -57,6 +57,7 @@ const OPTIONS_INFO = {
 	"browser-arg": { description: "Argument passed to the browser", type: "string[]", alias: "browser-argument" },
 	"browser-args": { description: "Arguments provided as a JSON array and passed to the browser", type: "string" },
 	"browser-start-minimized": { description: "Minimize the browser", type: "boolean" },
+	"browser-mobile-emulation": { description: "Emulate a mobile device", type: "boolean" },
 	"browser-cookie": { description: "Ordered list of cookie parameters separated by a comma (name,value,domain,path,expires,httpOnly,secure,sameSite,url)", type: "string[]" },
 	"browser-cookies-file": { description: "Path of the cookies file formatted as a JSON file or a Netscape text file", type: "string" },
 	"browser-ignore-insecure-certs": { description: "Ignore HTTPs errors", type: "boolean" },


### PR DESCRIPTION
This PR is created to resolve issue #89.

It allows to use **mobileEmulation** mode when Chrome pretends to be a mobile device.
Be default it sets as Android device with hardcoded resolution.

This is straightforward solution which works fine for me.
I personally don't think users need much customisation such as providing platform or user agent.
