### PR TITLE
Align --browser-server argument naming with its expected usage

### DIFF
--- a/lib/cdp-client.js
+++ b/lib/cdp-client.js
@@ -39,8 +39,8 @@ const SET_PAGE_DATA_FUNCTION_NAME = "setPageData";
 export { initialize, getPageData, closeBrowser };
 
 async function initialize(singleFileOptions) {
-	if (options.browserRemoteDebuggingURL) {
-		options.apiUrl = singleFileOptions.browserRemoteDebuggingURL;
+	if (singleFileOptions.browserServer) {
+		options.apiUrl = singleFileOptions.browserServer;
 	} else {
 		options.apiUrl = "http://localhost:" + (await launchBrowser(getBrowserOptions(singleFileOptions)));
 	}

--- a/single-file-cli-api.js
+++ b/single-file-cli-api.js
@@ -132,7 +132,7 @@ async function finish(options) {
 			}
 		}
 	}
-	if (!options.browserDebug && !options.browserRemoteDebuggingURL) {
+	if (!options.browserDebug && !options.browserServer) {
 		return backend.closeBrowser();
 	}
 }


### PR DESCRIPTION
Trying to run the Single File CLI against an external browser lead me to finding this issue:
`browserRemoteDebuggingURL` is not configured as a possible argument in the CLI, and by the current translation from argument name to and attribute of `options` it could never be named with capital URL
On the other hand, the `browserServer` was defined as an argument but wasn't being used anywhere in the code

I might have misunderstood the intentions of the two attributes/arguments and the differences between them but thought I'd suggest this fix to allow others to use external browsers 

Solves #93