### PR TITLE
Fixes "ReferenceError: Cannot access 'options' before initialization"

### DIFF
--- a/lib/cdp-client.js
+++ b/lib/cdp-client.js
@@ -92,16 +92,16 @@ async function getPageData(options) {
 				if (!options.userAgent) {
 					({ browserUserAgent } = await Browser.getVersion());
 				}
-				const options = {
+				const agentOptions = {
 					userAgent: options.userAgent || (options.browserMobileEmulation ? "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome Mobile Safari/537.36" : browserUserAgent)
 				};
 				if (options.acceptLanguage) {
-					options.acceptLanguage = options.acceptLanguage;
+					agentOptions.acceptLanguage = options.acceptLanguage;
 				}
 				if (options.platform || options.browserMobileEmulation) {
-					options.platform = options.platform || "Android";
+					agentOptions.platform = options.platform || "Android";
 				}
-				await Emulation.setUserAgentOverride(options);
+				await Emulation.setUserAgentOverride(agentOptions);
 			}
 		}
 		if (options.httpProxyUsername) {


### PR DESCRIPTION
When using browser mobile emulation, the program crashed because on that scope, we were using options before re-declaring them. It's also less confusing to differentiate both variable names.