### PR TITLE
Fix `--crawl-replace-URLs` when used with `--output-directory`

### DIFF
--- a/single-file-cli-api.js
+++ b/single-file-cli-api.js
@@ -127,7 +127,8 @@ async function finish(options) {
 	if (options.crawlReplaceURLs && !options.compressContent) {
 		for (const task of tasks) {
 			try {
-				let pageContent = await readTextFile(task.filename);
+				const outputFilename = options.outputDirectory + task.filename;
+				let pageContent = await readTextFile(outputFilename);
 				tasks.forEach(otherTask => {
 					if (otherTask.filename) {
 						pageContent = pageContent.replace(new RegExp(escapeRegExp("\"" + otherTask.originalUrl + "\""), "gi"), "\"" + otherTask.filename + "\"");
@@ -137,7 +138,7 @@ async function finish(options) {
 						pageContent = pageContent.replace(new RegExp(escapeRegExp("=" + otherTask.originalUrl + ">"), "gi"), "=" + filename + ">");
 					}
 				});
-				await writeTextFile(task.filename, pageContent);
+				await writeTextFile(outputFilename, pageContent);
 			} catch {
 				// ignored
 			}
@@ -333,19 +334,7 @@ async function capturePage(options) {
 }
 
 async function getFilename(filename, options, index = 1) {
-	if (Array.isArray(options.outputDirectory)) {
-		const outputDirectory = options.outputDirectory.pop();
-		if (outputDirectory.startsWith("/")) {
-			options.outputDirectory = outputDirectory;
-		} else {
-			options.outputDirectory = options.outputDirectory[0] + outputDirectory;
-		}
-	}
-	let outputDirectory = options.outputDirectory || "";
-	if (outputDirectory && !outputDirectory.endsWith("/")) {
-		outputDirectory += "/";
-	}
-	let newFilename = outputDirectory + filename;
+	let newFilename = options.outputDirectory + filename;
 	if (options.filenameConflictAction == "overwrite") {
 		return filename;
 	} else if (options.filenameConflictAction == "uniquify" && index > 1) {

--- a/single-file-launcher.js
+++ b/single-file-launcher.js
@@ -99,6 +99,18 @@ async function run() {
 			options.embeddedPdf = Array.from(await readFile(options.embeddedPdf));
 		}
 		options.retrieveLinks = true;
+		if (Array.isArray(options.outputDirectory)) {
+			const outputDirectory = options.outputDirectory.pop();
+			if (outputDirectory.startsWith("/")) {
+				options.outputDirectory = outputDirectory;
+			} else {
+				options.outputDirectory = options.outputDirectory[0] + outputDirectory;
+			}
+		}
+		options.outputDirectory = options.outputDirectory || "./"
+		if (!options.outputDirectory.endsWith("/")) {
+			options.outputDirectory += "/";
+		}
 		const singlefile = await initialize(options);
 		await singlefile.capture(urls);
 		await singlefile.finish();


### PR DESCRIPTION
- Initialize/update options.outputDirectory to a good string in single-file-launcher.js
- Use it to open files when replacing URLs

Note that prepending outputDirectory to pageData.filename or task.filename won't work. Downloaded files will have their references to URLs replaced by references to some task.filename. This means task.filename needs to be a path relative to the parent task's filename. The parent task's file is already saved in the outputDirectory, meaning we should not prepend outputDirectory.

The only time we prepend outputDirectory is when a path will be interpreted relative to the program's current working directory, such when opening a file for reading.

Possibly fixes #131.