### PR TITLE
fix stack overflow when fetching large resources

### DIFF
--- a/lib/cdp-client-util.js
+++ b/lib/cdp-client-util.js
@@ -83,7 +83,7 @@ function waitForTimeout(abortSignal, maxDelay, errorMessage, errorCode) {
 }
 
 function arrayBufferToBase64(arrayBuffer) {
-	return btoa(String.fromCharCode.apply(null, new Uint8Array(arrayBuffer)));
+	return new Uint8Array(arrayBuffer).toBase64();
 }
 
 function getAlternativeUrl(url) {


### PR DESCRIPTION
In arrayBufferToBase64, use the new thing.

Fixes #191.