### PR TITLE
Fix parsing of `emulateMediaFeatures`

### DIFF
--- a/lib/cdp-client.js
+++ b/lib/cdp-client.js
@@ -336,13 +336,14 @@ async function setupHttpHeaders({ Network }, { options, debugMessages }) {
 }
 
 async function setupMediaFeatures({ Emulation }, { options, debugMessages }) {
+	const features = [];
 	for (const mediaFeature of options.emulateMediaFeatures) {
 		logData(["Emulating media feature", mediaFeature.name, mediaFeature.value], { options, debugMessages });
-		await Emulation.setEmulatedMedia({
-			media: mediaFeature.name,
-			features: mediaFeature.value.split(",").map(feature => feature.trim())
-		});
+		for (const value of mediaFeature.value.split(",")) {
+			features.push({ name: mediaFeature.name, value: value.trim() });
+		}
 	}
+	await Emulation.setEmulatedMedia({ features });
 }
 
 async function setupCookies({ Network }, { options, debugMessages }) {

--- a/single-file-launcher.js
+++ b/single-file-launcher.js
@@ -84,6 +84,15 @@ async function run() {
 				options.browserCookies = parseCookies(cookiesContent);
 			}
 		}
+		if (options.emulateMediaFeatures) {
+			options.emulateMediaFeatures = options.emulateMediaFeatures.map(feature => {
+				const colonIndex = feature.indexOf(":");
+				return {
+					name: feature.substring(0, colonIndex),
+					value: feature.substring(colonIndex + 1)
+				};
+			});
+		}
 		if (options.httpHeaders) {
 			const headers = {};
 			for (const header of options.httpHeaders) {


### PR DESCRIPTION
Currently the parsing of media features is broken with this fix it is possible again to pass features.